### PR TITLE
fix: パスワードの最低文字数を15文字に変更

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -181,7 +181,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..64
+  config.password_length = 15..64
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user do
     name { "テストユーザー" }
     email { "test_#{SecureRandom.uuid}@example.com" }
-    password { "ikurahaikaga12" }
-    password_confirmation { "ikurahaikaga12" }
+    password { "ikurahaikaga123" }
+    password_confirmation { "ikurahaikaga123" }
   end
 end


### PR DESCRIPTION
## 実施内容
- パスワードの最低文字数を8文字から15文字に変更
    単一要素認証の場合は15文字以上を推奨しているため

## 確認内容
- 15文字未満のパスワードで登録しようとするとエラーになる

Closes #160 